### PR TITLE
Fix: `autofocus` prop autofocuses input on mount 

### DIFF
--- a/.changeset/mighty-parents-watch.md
+++ b/.changeset/mighty-parents-watch.md
@@ -1,0 +1,5 @@
+---
+"cmdk-sv": patch
+---
+
+Fix: `autofocus` prop autofocuses input on mount 

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,3 +13,4 @@ package-lock.json
 yarn.lock
 /dist
 .vercel
+.changeset

--- a/src/docs/components/cmdk/framer/framer-cmdk.svelte
+++ b/src/docs/components/cmdk/framer/framer-cmdk.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Command } from '$lib';
-	import { onMount, type ComponentType, tick } from 'svelte';
+	import type { ComponentType } from 'svelte';
 	import {
 		AvatarIcon,
 		BadgeIcon,
@@ -14,11 +14,7 @@
 	import '$styles/cmdk/framer.postcss';
 
 	let value = 'Button';
-	let inputEl: HTMLInputElement;
 
-	onMount(() => {
-		tick().then(() => inputEl?.focus());
-	});
 	type Component = {
 		value: string;
 		subtitle: string;
@@ -68,11 +64,7 @@
 	<Command.Root bind:value>
 		<div data-cmdk-framer-header="">
 			<SearchIcon />
-			<Command.Input
-				autofocus
-				placeholder="Find components, packages, and interactions..."
-				bind:el={inputEl}
-			/>
+			<Command.Input autofocus placeholder="Find components, packages, and interactions..." />
 		</div>
 		<Command.List>
 			<div data-cmdk-framer-items="">

--- a/src/docs/components/cmdk/linear/linear-cmdk.svelte
+++ b/src/docs/components/cmdk/linear/linear-cmdk.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onMount, type ComponentType, tick } from 'svelte';
+	import type { ComponentType } from 'svelte';
 	import { Command } from '$lib';
 	import {
 		AssignToIcon,
@@ -55,17 +55,12 @@
 			shortcut: ['⇧', 'D']
 		}
 	];
-	let inputEl: HTMLInputElement;
-
-	onMount(() => {
-		tick().then(() => inputEl?.focus());
-	});
 </script>
 
 <div class="linear">
 	<Command.Root>
 		<div data-cmdk-linear-badge="">Issue - FUN-343</div>
-		<Command.Input autofocus placeholder="Type a command or search..." bind:el={inputEl} />
+		<Command.Input autofocus placeholder="Type a command or search..." />
 		<Command.List>
 			<Command.Empty>No results found.</Command.Empty>
 			{#each items as { label, shortcut, icon }}

--- a/src/docs/components/cmdk/raycast/raycast-cmdk.svelte
+++ b/src/docs/components/cmdk/raycast/raycast-cmdk.svelte
@@ -13,15 +13,10 @@
 	import Logo from '$docs/components/logo.svelte';
 	import { Command } from '$lib';
 	import SubCommand from './sub-command.svelte';
-	import { onMount, tick } from 'svelte';
 
 	let value = 'linear';
 	let inputEl: HTMLInputElement | undefined;
 	let listEl: HTMLElement | undefined;
-
-	onMount(() => {
-		tick().then(() => inputEl?.focus());
-	});
 </script>
 
 <div class="raycast">

--- a/src/docs/components/cmdk/raycast/sub-command.svelte
+++ b/src/docs/components/cmdk/raycast/sub-command.svelte
@@ -12,7 +12,7 @@
 
 	onMount(() => {
 		function handleKeydown(e: KeyboardEvent) {
-			if (e.key === 'k' && e.metaKey) {
+			if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
 				e.preventDefault();
 				open = true;
 			}

--- a/src/docs/components/cmdk/vercel/vercel-cmdk.svelte
+++ b/src/docs/components/cmdk/vercel/vercel-cmdk.svelte
@@ -4,10 +4,8 @@
 	import Home from './home.svelte';
 	import Projects from './projects.svelte';
 	import '$styles/cmdk/vercel.postcss';
-	import { onMount, tick } from 'svelte';
 
 	let inputValue: string;
-	let inputEl: HTMLInputElement;
 
 	let pages: string[] = ['home'];
 	$: activePage = pages[pages.length - 1];
@@ -46,10 +44,6 @@
 			bounce(currTarget);
 		}
 	}
-
-	onMount(() => {
-		tick().then(() => inputEl?.focus());
-	});
 </script>
 
 <div class="vercel">
@@ -61,12 +55,7 @@
 				</div>
 			{/each}
 		</div>
-		<Command.Input
-			autofocus
-			placeholder="What do you need?"
-			bind:value={inputValue}
-			bind:el={inputEl}
-		/>
+		<Command.Input autofocus placeholder="What do you need?" bind:value={inputValue} />
 		<Command.List>
 			<Command.Empty>No results found.</Command.Empty>
 			{#if activePage === 'home'}

--- a/src/lib/cmdk/components/CommandInput.svelte
+++ b/src/lib/cmdk/components/CommandInput.svelte
@@ -3,6 +3,7 @@
 	import { ITEM_SELECTOR, VALUE_ATTR, getCtx, getState } from '../command.js';
 	import { isBrowser, isHTMLInputElement } from '$lib/internal/index.js';
 	import type { InputProps } from '../types.js';
+	import { onMount } from 'svelte';
 
 	type $$Props = InputProps;
 
@@ -11,9 +12,16 @@
 	const search = derived(state, ($state) => $state.search);
 	const valueStore = derived(state, ($state) => $state.value);
 
+	export let autofocus: $$Props['autofocus'] = undefined;
 	export let el: HTMLElement | undefined = undefined;
 
 	export let value: $$Props['value'] = $search;
+
+	onMount(() => {
+		if (autofocus) {
+			el?.focus();
+		}
+	});
 
 	const selectedItemId = derived([valueStore, commandEl], ([$value, $commandEl]) => {
 		if (!isBrowser) return undefined;


### PR DESCRIPTION
- focus the input onMount when the `autofocus` prop is `true`.
- add support for `ctrl+k` for windows users in Raycast demo (#7)

Closes: #7 