### PR TITLE
Add `asChild` prop & forward input events

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,7 +10,7 @@ module.exports = {
 	plugins: ['@typescript-eslint'],
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 'lastest',
+		ecmaVersion: 'latest',
 		extraFileExtensions: ['.svelte']
 	},
 	env: {
@@ -18,20 +18,9 @@ module.exports = {
 		es2024: true,
 		node: true
 	},
-	overrides: [
-		{
-			files: ['*.svelte'],
-			parser: 'svelte-eslint-parser',
-			parserOptions: {
-				parser: '@typescript-eslint/parser'
-			}
-		}
-	],
+	globals: { $$Generic: 'readable', NodeJS: true },
 	rules: {
-		// eslint
 		'no-console': 'warn',
-
-		// @typescript-eslint
 		'@typescript-eslint/no-unused-vars': [
 			'warn',
 			{
@@ -39,22 +28,48 @@ module.exports = {
 				varsIgnorePattern: '^_'
 			}
 		],
-
-		// eslint-plugin-svelte
 		'svelte/no-target-blank': 'error',
 		'svelte/no-immutable-reactive-statements': 'error',
 		'svelte/prefer-style-directive': 'error',
 		'svelte/no-reactive-literals': 'error',
 		'svelte/no-useless-mustaches': 'error',
-		// TODO: opt in to these at a later stage
 		'svelte/button-has-type': 'off',
 		'svelte/require-each-key': 'off',
 		'svelte/no-at-html-tags': 'off',
 		'svelte/no-unused-svelte-ignore': 'off',
 		'svelte/require-stores-init': 'off'
 	},
-	globals: {
-		NodeJS: true,
-		$$Generic: 'readable'
-	}
+	overrides: [
+		{
+			files: ['*.svelte'],
+			parser: 'svelte-eslint-parser',
+			parserOptions: {
+				parser: '@typescript-eslint/parser'
+			},
+			rules: {
+				'@typescript-eslint/no-unused-vars': [
+					'warn',
+					{
+						argsIgnorePattern: '^_',
+						varsIgnorePattern: '^\\$\\$(Props|Events|Slots|Generic)$'
+					}
+				]
+			}
+		},
+		{
+			files: ['*.ts'],
+			parser: '@typescript-eslint/parser',
+			rules: {
+				'@typescript-eslint/ban-types': [
+					'error',
+					{
+						extendDefaults: true,
+						types: {
+							'{}': false
+						}
+					}
+				]
+			}
+		}
+	]
 };

--- a/README.md
+++ b/README.md
@@ -438,6 +438,12 @@ Render `Command` inside of the popover content:
 
 You can find global stylesheets to drop in as a starting point for styling. See [src/styles/cmdk](src/styles/cmdk) for examples.
 
+### Render Delegation
+
+Each of the components (except the dialog) accept an `asChild` prop that can be used to render a custom element in place of the default. When using this prop, you'll need to check the components slot props to see what attributes & actions you'll need to pass to your custom element.
+
+Components that contain only a single element will just have `attrs` & `action` slot props, or just `attrs`. Components that contain multiple elements will have an `attrs` and possibly an `actions` object whose properties are the attributes and actions for each element.
+
 ## FAQ
 
 **Accessible?** Yes. Labeling, aria attributes, and DOM ordering tested with Voice Over and Chrome DevTools. [Dialog](#dialog-cmdk-dialog-cmdk-overlay) composes an accessible Dialog implementation.

--- a/src/lib/cmdk/command.ts
+++ b/src/lib/cmdk/command.ts
@@ -73,11 +73,28 @@ const defaults = {
 	loop: false,
 	onValueChange: undefined,
 	value: undefined,
-	filter: defaultFilter
+	filter: defaultFilter,
+	ids: {
+		root: generateId(),
+		list: generateId(),
+		label: generateId(),
+		input: generateId()
+	}
 } satisfies CommandProps;
 
 export function createCommand(props: CommandProps) {
-	const withDefaults = { ...defaults, ...removeUndefined(props) } satisfies CommandProps;
+	const ids = {
+		root: generateId(),
+		list: generateId(),
+		label: generateId(),
+		input: generateId(),
+		...props.ids
+	};
+
+	const withDefaults = {
+		...defaults,
+		...removeUndefined(props)
+	} satisfies CommandProps;
 
 	const state =
 		props.state ??
@@ -90,15 +107,8 @@ export function createCommand(props: CommandProps) {
 	const allIds = writable<Map<string, string>>(new Map()); // id → value
 	const commandEl = writable<HTMLDivElement | null>(null);
 
-	const options = toWritableStores(omit(withDefaults, 'value'));
+	const options = toWritableStores(omit(withDefaults, 'value', 'ids'));
 	const { shouldFilter, loop, filter, label } = options;
-
-	const ids = {
-		root: generateId(),
-		list: generateId(),
-		label: generateId(),
-		input: generateId()
-	};
 
 	const context: Context = {
 		value: (id, value) => {

--- a/src/lib/cmdk/components/CommandEmpty.svelte
+++ b/src/lib/cmdk/components/CommandEmpty.svelte
@@ -7,6 +7,8 @@
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	type $$Props = EmptyProps;
 
+	export let asChild: $$Props['asChild'] = false;
+
 	let isFirstRender = true;
 
 	onMount(() => {
@@ -15,10 +17,19 @@
 
 	const state = getState();
 	const render = derived(state, ($state) => $state.filtered.count === 0);
+
+	const attrs = {
+		'data-cmdk-empty': '',
+		role: 'presentation'
+	};
 </script>
 
 {#if !isFirstRender && $render}
-	<div data-cmdk-empty="" role="presentation" {...$$restProps}>
-		<slot />
-	</div>
+	{#if asChild}
+		<slot {attrs} />
+	{:else}
+		<div {...attrs} {...$$restProps}>
+			<slot />
+		</div>
+	{/if}
 {/if}

--- a/src/lib/cmdk/components/CommandGroup.svelte
+++ b/src/lib/cmdk/components/CommandGroup.svelte
@@ -10,6 +10,7 @@
 	export let heading: $$Props['heading'] = undefined;
 	export let value = '';
 	export let alwaysRender: $$Props['alwaysRender'] = false;
+	export let asChild: $$Props['asChild'] = false;
 
 	const { id } = createGroup(alwaysRender);
 
@@ -29,7 +30,7 @@
 		return unsubGroup;
 	});
 
-	function groupAction(node: HTMLElement) {
+	function containerAction(node: HTMLElement) {
 		if (value) {
 			context.value(id, value);
 			node.setAttribute(VALUE_ATTR, value);
@@ -45,22 +46,47 @@
 		context.value(id, value);
 		node.setAttribute(VALUE_ATTR, value);
 	}
+
+	$: containerAttrs = {
+		'data-cmdk-group': '',
+		role: 'presentation',
+		hidden: $render ? undefined : true,
+		'data-value': value
+	};
+
+	const headingAttrs = {
+		'data-cmdk-group-heading': '',
+		'aria-hidden': true,
+		id: headingId
+	};
+
+	$: groupAttrs = {
+		'data-cmdk-group-items': '',
+		role: 'group',
+		'aria-labelledby': heading ? headingId : undefined
+	};
+
+	$: container = {
+		action: containerAction,
+		attrs: containerAttrs
+	};
+
+	$: group = {
+		attrs: groupAttrs
+	};
 </script>
 
-<div
-	use:groupAction
-	data-cmdk-group=""
-	role="presentation"
-	hidden={$render ? undefined : true}
-	data-value={value}
-	{...$$restProps}
->
-	{#if heading}
-		<div data-cmdk-group-heading="" aria-hidden id={headingId}>
-			{heading}
+{#if asChild}
+	<slot {container} {group} heading={{ attrs: headingAttrs }} />
+{:else}
+	<div use:containerAction {...containerAttrs} {...$$restProps}>
+		{#if heading}
+			<div {...headingAttrs}>
+				{heading}
+			</div>
+		{/if}
+		<div {...groupAttrs}>
+			<slot {container} {group} heading={{ attrs: headingAttrs }} />
 		</div>
-	{/if}
-	<div data-cmdk-group-items="" role="group" aria-labelledby={heading ? headingId : undefined}>
-		<slot />
 	</div>
-</div>
+{/if}

--- a/src/lib/cmdk/components/CommandItem.svelte
+++ b/src/lib/cmdk/components/CommandItem.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { generateId, isUndefined } from '$lib/internal';
+	import { addEventListener, executeCallbacks, generateId, isUndefined } from '$lib/internal';
 	import { onMount } from 'svelte';
 	import { VALUE_ATTR, getCtx, getGroup, getState } from '../command.js';
 	import type { ItemProps } from '../types.js';
@@ -11,8 +11,9 @@
 	export let value: string = '';
 	export let onSelect: $$Props['onSelect'] = undefined;
 	export let alwaysRender: $$Props['alwaysRender'] = false;
+	export let asChild: $$Props['asChild'] = false;
+	export let id: string = generateId();
 
-	const id = generateId();
 	const groupContext = getGroup();
 	const context = getCtx();
 	const state = getState();
@@ -33,12 +34,29 @@
 		return unsubItem;
 	});
 
-	function itemAction(node: HTMLElement) {
+	function action(node: HTMLElement) {
 		if (!value && node.textContent) {
 			value = node.textContent.trim().toLowerCase();
 		}
 		context.value(id, value);
 		node.setAttribute(VALUE_ATTR, value);
+
+		const unsubEvents = executeCallbacks(
+			addEventListener(node, 'pointermove', () => {
+				if (disabled) return;
+				select();
+			}),
+			addEventListener(node, 'click', () => {
+				if (disabled) return;
+				handleItemClick();
+			})
+		);
+
+		return {
+			destroy() {
+				unsubEvents();
+			}
+		};
 	}
 
 	function handleItemClick() {
@@ -49,24 +67,27 @@
 	function select() {
 		state.updateState('value', value, true);
 	}
+
+	$: attrs = {
+		'aria-disabled': disabled ? true : undefined,
+		'aria-selected': $selected ? true : undefined,
+		'data-disabled': disabled ? true : undefined,
+		'data-selected': $selected ? true : undefined,
+		'data-cmdk-item': '',
+		'data-value': value,
+		role: 'option',
+		id
+	};
 </script>
 
 {#if $render}
-	<!-- svelte-ignore a11y-interactive-supports-focus -->
-	<div
-		{id}
-		role="option"
-		use:itemAction
-		aria-disabled={disabled || undefined}
-		aria-selected={$selected || undefined}
-		data-disabled={disabled || undefined}
-		data-selected={$selected || undefined}
-		data-cmdk-item=""
-		data-value={value}
-		on:pointermove={disabled ? undefined : select}
-		on:click={disabled ? undefined : handleItemClick}
-		{...$$restProps}
-	>
-		<slot />
-	</div>
+	{#if asChild}
+		<slot {action} {attrs} />
+	{:else}
+		<!-- svelte-ignore a11y-interactive-supports-focus -->
+		<!-- svelte-ignore a11y-no-static-element-interactions -->
+		<div {...attrs} use:action {...$$restProps}>
+			<slot {action} {attrs} />
+		</div>
+	{/if}
 {/if}

--- a/src/lib/cmdk/components/CommandList.svelte
+++ b/src/lib/cmdk/components/CommandList.svelte
@@ -9,6 +9,7 @@
 	type $$Props = ListProps;
 
 	export let el: $$Props['el'] = undefined;
+	export let asChild: $$Props['asChild'] = false;
 
 	function sizerAction(node: HTMLElement) {
 		let animationFrame: number;
@@ -32,18 +33,35 @@
 			}
 		};
 	}
+
+	const listAttrs = {
+		'data-cmdk-list': '',
+		role: 'listbox',
+		'aria-label': 'Suggestions',
+		id: ids.list,
+		'aria-labelledby': ids.input
+	};
+
+	const sizerAttrs = {
+		'data-cmdk-list-sizer': ''
+	};
+
+	const list = {
+		attrs: listAttrs
+	};
+
+	const sizer = {
+		attrs: sizerAttrs,
+		action: sizerAction
+	};
 </script>
 
-<div
-	data-cmdk-list=""
-	role="listbox"
-	aria-label="Suggestions"
-	id={ids.list}
-	aria-labelledby={ids.input}
-	bind:this={el}
-	{...$$restProps}
->
-	<div data-cmdk-list-sizer="" use:sizerAction>
-		<slot />
+{#if asChild}
+	<slot {list} {sizer} />
+{:else}
+	<div {...listAttrs} bind:this={el} {...$$restProps}>
+		<div {...sizerAttrs} use:sizerAction>
+			<slot />
+		</div>
 	</div>
-</div>
+{/if}

--- a/src/lib/cmdk/components/CommandLoading.svelte
+++ b/src/lib/cmdk/components/CommandLoading.svelte
@@ -3,18 +3,24 @@
 
 	type $$Props = LoadingProps;
 	export let progress: $$Props['progress'] = 0;
+	export let asChild: $$Props['asChild'] = false;
+
+	$: attrs = {
+		'data-cmdk-loading': '',
+		role: 'progressbar',
+		'aria-valuenow': progress,
+		'aria-valuemin': 0,
+		'aria-valuemax': 100,
+		'aria-label': 'Loading...'
+	};
 </script>
 
-<div
-	data-cmdk-loading=""
-	role="progressbar"
-	aria-valuenow={progress}
-	aria-valuemin={0}
-	aria-valuemax={100}
-	aria-label="Loading..."
-	{...$$restProps}
->
-	<div aria-hidden>
-		<slot />
+{#if asChild}
+	<slot {attrs} />
+{:else}
+	<div {...attrs} {...$$restProps}>
+		<div aria-hidden>
+			<slot {attrs} />
+		</div>
 	</div>
-</div>
+{/if}

--- a/src/lib/cmdk/components/CommandSeparator.svelte
+++ b/src/lib/cmdk/components/CommandSeparator.svelte
@@ -6,10 +6,21 @@
 	type $$Props = SeparatorProps;
 
 	export let alwaysRender: $$Props['alwaysRender'] = false;
+	export let asChild: $$Props['asChild'] = false;
+
 	const state = getState();
 	const render = derived(state, ($state) => !$state.search);
+
+	const attrs = {
+		'data-cmdk-separator': '',
+		role: 'separator'
+	};
 </script>
 
 {#if $render || alwaysRender}
-	<div data-cmdk-separator="" role="separator" {...$$restProps} />
+	{#if asChild}
+		<slot {attrs} />
+	{:else}
+		<div {...attrs} {...$$restProps} />
+	{/if}
 {/if}

--- a/src/lib/cmdk/types.ts
+++ b/src/lib/cmdk/types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import type { Expand, HTMLDivAttributes, Transition, PrefixKeys } from '$lib/internal';
 import type { Dialog as DialogPrimitive } from 'bits-ui';
-import type { HTMLInputAttributes } from 'svelte/elements';
+import type { EventHandler, HTMLInputAttributes } from 'svelte/elements';
 import type { Writable } from 'svelte/store';
 
 //
@@ -11,9 +11,25 @@ import type { Writable } from 'svelte/store';
 export type LoadingProps = {
 	/** Estimated loading progress */
 	progress?: number;
+
+	/**
+	 * Whether to delegate rendering to a custom element.
+	 *
+	 * The contents within the `Loading` component should be marked
+	 * as `aria-hidden` to prevent screen readers from reading the
+	 * contents while loading.
+	 */
+	asChild?: boolean;
 } & HTMLDivAttributes;
 
-export type EmptyProps = HTMLDivAttributes;
+export type EmptyProps = {
+	/**
+	 * Whether to delegate rendering to a custom element.
+	 *
+	 * Only receives `attrs`, no `action`.
+	 */
+	asChild?: boolean;
+} & HTMLDivAttributes;
 
 export type SeparatorProps = {
 	/**
@@ -21,6 +37,11 @@ export type SeparatorProps = {
 	 * of the filter.
 	 */
 	alwaysRender?: boolean;
+
+	/**
+	 * Whether to delegate rendering to a custom element.
+	 */
+	asChild?: boolean;
 } & HTMLDivAttributes;
 
 type BaseCommandProps = {
@@ -71,13 +92,36 @@ type BaseCommandProps = {
 	loop?: boolean;
 };
 
-export type CommandProps = Expand<BaseCommandProps> & HTMLDivAttributes;
+export type CommandProps = Expand<
+	BaseCommandProps & {
+		/**
+		 * Optionally provide custom ids for the command menu
+		 * elements. These ids should be unique and are only
+		 * necessary in very specific cases. Use with caution.
+		 */
+		ids?: Partial<CommandIds>;
+	}
+> &
+	HTMLDivAttributes;
 
 export type ListProps = {
 	/**
 	 * The list element
 	 */
 	el?: HTMLElement;
+
+	/**
+	 * Whether to delegate rendering to a custom element.
+	 *
+	 * Provides 2 slot props: `container` & `list`.
+	 * Container only has an `attrs` property, while `list` has
+	 * `attrs` & `action` to be applied to the respective elements.
+	 *
+	 * The `list` wraps the `sizer`, and the `sizer` wraps the `items`, and
+	 * is responsible for measuring the height of the items and setting the
+	 * CSS variable to the height of the items.
+	 */
+	asChild?: boolean;
 } & HTMLDivAttributes;
 
 export type InputProps = {
@@ -85,6 +129,11 @@ export type InputProps = {
 	 * The list element
 	 */
 	el?: HTMLInputElement;
+
+	/**
+	 * Whether to delegate rendering to a custom element.
+	 */
+	asChild?: boolean;
 } & HTMLInputAttributes;
 
 export type GroupProps = {
@@ -104,6 +153,15 @@ export type GroupProps = {
 	 * regardless of filtering.
 	 */
 	alwaysRender?: boolean;
+
+	/**
+	 * Whether to delegate rendering to custom elements.
+	 *
+	 * Provides 3 slot props: `container`, `heading`, and `group`.
+	 * Container has `attrs` & `action`, while `heading` & `group`
+	 * only have `attrs` to be applied to the respective elements.
+	 */
+	asChild?: boolean;
 } & HTMLDivAttributes;
 
 export type ItemProps = {
@@ -131,6 +189,19 @@ export type ItemProps = {
 	 * regardless of filtering.
 	 */
 	alwaysRender?: boolean;
+
+	/**
+	 * Whether to delegate rendering to a custom element.
+	 * Will pass the `attrs` & `action` to be applied to the custom element.
+	 */
+	asChild?: boolean;
+
+	/**
+	 * Optionally override the default `id` generated for this item.
+	 * NOTE: This must be unique across all items and is only necessary
+	 * in very specific cases.
+	 */
+	id?: string;
 } & HTMLDivAttributes;
 
 type TransitionProps =
@@ -168,6 +239,17 @@ export type DialogProps<
 	DialogPrimitive.Props &
 	OverlayProps<OverlayT, OverlayIn, OverlayOut> &
 	ContentProps<ContentT, ContentIn, ContentOut>;
+
+//
+// Events
+//
+
+export type InputEvents<T extends Element = HTMLInputElement> = {
+	blur: EventHandler<FocusEvent, T>;
+	input: EventHandler<Event, T>;
+	focus: EventHandler<FocusEvent, T>;
+	change: EventHandler<Event, T>;
+};
 
 //
 // Internal

--- a/src/lib/internal/helpers/callbacks.ts
+++ b/src/lib/internal/helpers/callbacks.ts
@@ -1,0 +1,23 @@
+/**
+ * A callback function that takes an array of arguments of type `T` and returns `void`.
+ * @template T The types of the arguments that the callback function takes.
+ */
+export type Callback<T extends unknown[] = unknown[]> = (...args: T) => void;
+
+/**
+ * Executes an array of callback functions with the same arguments.
+ * @template T The types of the arguments that the callback functions take.
+ * @param n array of callback functions to execute.
+ * @returns A new function that executes all of the original callback functions with the same arguments.
+ */
+export function executeCallbacks<T extends unknown[]>(
+	...callbacks: Array<Callback<T>>
+): (...args: T) => void {
+	return (...args) => {
+		for (const callback of callbacks) {
+			if (typeof callback === 'function') {
+				callback(...args);
+			}
+		}
+	};
+}

--- a/src/lib/internal/helpers/event.ts
+++ b/src/lib/internal/helpers/event.ts
@@ -1,0 +1,59 @@
+import type { Arrayable } from '$lib/internal/index.js';
+
+/**
+ * A type alias for a general event listener function.
+ *
+ * @template E - The type of event to listen for
+ * @param evt - The event object
+ * @returns The return value of the event listener function
+ */
+export type GeneralEventListener<E = Event> = (evt: E) => unknown;
+
+/**
+ *  Overloaded function signatures for addEventListener
+ */
+export function addEventListener<E extends keyof HTMLElementEventMap>(
+	target: Window,
+	event: E,
+	handler: (this: Window, ev: HTMLElementEventMap[E]) => unknown,
+	options?: boolean | AddEventListenerOptions
+): VoidFunction;
+
+export function addEventListener<E extends keyof HTMLElementEventMap>(
+	target: Document,
+	event: E,
+	handler: (this: Document, ev: HTMLElementEventMap[E]) => unknown,
+	options?: boolean | AddEventListenerOptions
+): VoidFunction;
+
+export function addEventListener<E extends keyof HTMLElementEventMap>(
+	target: EventTarget,
+	event: E,
+	handler: GeneralEventListener<HTMLElementEventMap[E]>,
+	options?: boolean | AddEventListenerOptions
+): VoidFunction;
+
+/**
+ * Adds an event listener to the specified target element(s) for the given event(s), and returns a function to remove it.
+ * @param target The target element(s) to add the event listener to.
+ * @param event The event(s) to listen for.
+ * @param handler The function to be called when the event is triggered.
+ * @param options An optional object that specifies characteristics about the event listener.
+ * @returns A function that removes the event listener from the target element(s).
+ */
+export function addEventListener(
+	target: Window | Document | EventTarget,
+	event: Arrayable<string>,
+	handler: EventListenerOrEventListenerObject,
+	options?: boolean | AddEventListenerOptions
+) {
+	const events = Array.isArray(event) ? event : [event];
+
+	// Add the event listener to each specified event for the target element(s).
+	events.forEach((_event) => target.addEventListener(_event, handler, options));
+
+	// Return a function that removes the event listener from the target element(s).
+	return () => {
+		events.forEach((_event) => target.removeEventListener(_event, handler, options));
+	};
+}

--- a/src/lib/internal/helpers/index.ts
+++ b/src/lib/internal/helpers/index.ts
@@ -4,3 +4,5 @@ export * from './kbd.js';
 export * from './object.js';
 export * from './store.js';
 export * from './style.js';
+export * from './event.js';
+export * from './callbacks.js';

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -30,3 +30,5 @@ export type PrefixKeys<T, Prefix extends string> = Expand<{
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Transition = (node: Element, params?: any) => TransitionConfig;
+
+export type Arrayable<T> = T | T[];


### PR DESCRIPTION
Closes: #13

Adds `asChild` prop to render custom elements instead of elements provided automatically by the components.