### PR TITLE
fix: dont use onMount inside CommandInput action for autofocus

### DIFF
--- a/.changeset/olive-lobsters-whisper.md
+++ b/.changeset/olive-lobsters-whisper.md
@@ -1,0 +1,5 @@
+---
+"cmdk-sv": patch
+---
+
+fix: `autofocus` input behavior 

--- a/src/lib/cmdk/components/CommandInput.svelte
+++ b/src/lib/cmdk/components/CommandInput.svelte
@@ -3,7 +3,6 @@
 	import { ITEM_SELECTOR, VALUE_ATTR, getCtx, getState } from '../command.js';
 	import { addEventListener, isBrowser, isHTMLInputElement } from '$lib/internal/index.js';
 	import type { InputEvents, InputProps } from '../types.js';
-	import { onMount } from 'svelte';
 	import { sleep } from '$lib/internal/helpers/sleep.js';
 
 	type $$Props = InputProps;
@@ -31,11 +30,10 @@
 	}
 
 	function action(node: HTMLInputElement) {
-		onMount(() => {
-			if (autofocus) {
-				sleep(10).then(() => node.focus());
-			}
-		});
+		if (autofocus) {
+			sleep(10).then(() => node.focus());
+		}
+
 		const unsubEvents = addEventListener(node, 'change', (e) => {
 			if (!isHTMLInputElement(e.target)) return;
 			state.updateState('search', e.target.value);


### PR DESCRIPTION
The `onMount` used inside the CommandInput action is resulting in unreliable behaviour with the input autofocus behaviour actually firing. 

It's also unnecessary/unintended to be used inside of an action as far as I know, as the element mount/unmount should be enough.

EDIT: FYI you can observe the broken `autofocus` behaviour from the docs, when navigating between the different command menus: https://www.cmdk-sv.com/

Only the first menu receives autofocus when loading the page.