### PR TITLE
fix: Move `Command` additional props to be declared directly in `CommandProps` type

### DIFF
--- a/.changeset/bright-kangaroos-explode.md
+++ b/.changeset/bright-kangaroos-explode.md
@@ -1,0 +1,5 @@
+---
+'cmdk-sv': patch
+---
+
+fix: move Command additional props to types file

--- a/src/lib/cmdk/components/Command.svelte
+++ b/src/lib/cmdk/components/Command.svelte
@@ -8,10 +8,7 @@
 	import { createCommand } from '../command.js';
 	import type { CommandProps } from '../types.js';
 
-	type $$Props = CommandProps & {
-		onKeydown?: (e: KeyboardEvent) => void;
-		asChild?: boolean;
-	};
+	type $$Props = CommandProps;
 
 	export let label: $$Props['label'] = undefined;
 	export let shouldFilter: $$Props['shouldFilter'] = true;

--- a/src/lib/cmdk/types.ts
+++ b/src/lib/cmdk/types.ts
@@ -102,7 +102,10 @@ export type CommandProps = Expand<
 		ids?: Partial<CommandIds>;
 	}
 > &
-	HTMLDivAttributes;
+	HTMLDivAttributes & {
+		onKeydown?: (e: KeyboardEvent) => void;
+		asChild?: boolean;
+	};
 
 export type ListProps = {
 	/**


### PR DESCRIPTION
For whatever reason, the additional props declared on `$$Props` inside the `Command.svelte` component aren't included in the compiled output. Adding it directly to `CommandProps` resolves this problem.