### PR TITLE
fix: import specifier in src/lib/cmdk/types.ts

### DIFF
--- a/.changeset/happy-fishes-kick.md
+++ b/.changeset/happy-fishes-kick.md
@@ -1,0 +1,5 @@
+---
+'cmdk-sv': patch
+---
+
+Fix type resolution and intellisense for most components

--- a/src/lib/cmdk/types.ts
+++ b/src/lib/cmdk/types.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import type { Expand, HTMLDivAttributes, Transition, PrefixKeys } from '$lib/internal';
+import type { Expand, HTMLDivAttributes, Transition, PrefixKeys } from '$lib/internal/index.js';
 import type { Dialog as DialogPrimitive } from 'bits-ui';
 import type { EventHandler, HTMLInputAttributes } from 'svelte/elements';
 import type { Writable } from 'svelte/store';


### PR DESCRIPTION
The import specifier references a folder, which isn't allowed in ESM.

`$lib/internal`

should be 

`$lib/internal/index.js`

This is breaking type resolution and intellisense for all the components.