### PR TITLE
Fix typo in InputProps TypeDocs

### DIFF
--- a/src/lib/cmdk/types.ts
+++ b/src/lib/cmdk/types.ts
@@ -129,7 +129,7 @@ export type ListProps = {
 
 export type InputProps = {
 	/**
-	 * The list element
+	 * The input element
 	 */
 	el?: HTMLInputElement;
 


### PR DESCRIPTION
I'm guessing this was copy-pasted from `ListProps` right above and accidentally missed.