### PR TITLE
fix: large list performance

### DIFF
--- a/.changeset/chilly-eagles-add.md
+++ b/.changeset/chilly-eagles-add.md
@@ -1,0 +1,5 @@
+---
+"cmdk-sv": patch
+---
+
+Fixed bug where page would crash when a large list was rendered

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -30,7 +30,6 @@ module.exports = {
 		],
 		'svelte/no-target-blank': 'error',
 		'svelte/no-immutable-reactive-statements': 'error',
-		'svelte/prefer-style-directive': 'error',
 		'svelte/no-reactive-literals': 'error',
 		'svelte/no-useless-mustaches': 'error',
 		'svelte/button-has-type': 'off',

--- a/src/lib/cmdk/components/Command.svelte
+++ b/src/lib/cmdk/components/Command.svelte
@@ -43,6 +43,7 @@
 	});
 
 	function syncValueAndState(value: string | undefined) {
+		console.log('sync value and state');
 		if (value && value !== $stateStore.value) {
 			$stateStore.value = value;
 		}

--- a/src/lib/cmdk/components/CommandInput.svelte
+++ b/src/lib/cmdk/components/CommandInput.svelte
@@ -48,7 +48,7 @@
 
 	$: if (value !== undefined) {
 		if (withSleep) {
-			sleep(100).then(() => {
+			sleep(1).then(() => {
 				handleValueUpdate(value);
 			});
 		} else {

--- a/src/lib/cmdk/components/CommandInput.svelte
+++ b/src/lib/cmdk/components/CommandInput.svelte
@@ -16,7 +16,6 @@
 	export let autofocus: $$Props['autofocus'] = undefined;
 	export let value: $$Props['value'] = get(search);
 	export let asChild: $$Props['asChild'] = false;
-	export let withSleep = false;
 
 	export let el: HTMLElement | undefined = undefined;
 
@@ -46,15 +45,7 @@
 		}
 	}
 
-	$: if (value !== undefined) {
-		if (withSleep) {
-			sleep(1).then(() => {
-				handleValueUpdate(value);
-			});
-		} else {
-			handleValueUpdate(value);
-		}
-	}
+	$: handleValueUpdate(value);
 
 	let attrs: Record<string, unknown>;
 

--- a/src/routes/sink/+page.svelte
+++ b/src/routes/sink/+page.svelte
@@ -1,5 +1,5 @@
-<script>
-	import { Command } from '$lib';
+<script lang="ts">
+	import { Command } from '$lib/index.js';
 
 	// prettier-ignore
 	const ten_first_names = ["John", "Doe", "Jane", "Smith", "Michael", "Brown", "William", "Johnson", "David", "Williams"];
@@ -17,49 +17,21 @@
 			});
 		})
 		.flat(2)
-		.slice(350);
-
-	let view = 'sync';
+		.slice(500);
 </script>
 
 <div style:padding="16px">
-	<div style:padding-bottom="16px" style:padding-top="16px">
-		<label for="sync">
-			<input type="radio" name="view" value="sync" bind:group={view} />
-			Sync
-		</label>
-		<label for="async" style="padding-left: 16px;">
-			<input type="radio" name="view" value="async" bind:group={view} />
-			Async
-		</label>
-	</div>
-	{#if view === 'async'}
-		<Command.Root loop>
-			<Command.Input withSleep placeholder="Search items..." />
-			<Command.Empty>No item found.</Command.Empty>
+	<Command.Root loop>
+		<Command.Input placeholder="Search items..." />
+		<Command.Empty>No item found.</Command.Empty>
 
-			<Command.List
-				class="h-[var(--cmdk-list-height)]"
-				style="height: 200px; overflow-y: auto; max-width: 300px;"
-			>
-				{#each names as txt (txt)}
-					<Command.Item value={txt}>{txt}</Command.Item>
-				{/each}
-			</Command.List>
-		</Command.Root>
-	{:else}
-		<Command.Root loop>
-			<Command.Input placeholder="Search items..." />
-			<Command.Empty>No item found.</Command.Empty>
-
-			<Command.List
-				class="h-[var(--cmdk-list-height)]"
-				style="height: 200px; overflow-y: auto; max-width: 300px;"
-			>
-				{#each names as txt (txt)}
-					<Command.Item value={txt}>{txt}</Command.Item>
-				{/each}
-			</Command.List>
-		</Command.Root>
-	{/if}
+		<Command.List
+			class="h-[var(--cmdk-list-height)]"
+			style="height: 200px; overflow-y: auto; max-width: 300px;"
+		>
+			{#each names as txt (txt)}
+				<Command.Item value={txt}>{txt}</Command.Item>
+			{/each}
+		</Command.List>
+	</Command.Root>
 </div>

--- a/src/routes/sink/+page.svelte
+++ b/src/routes/sink/+page.svelte
@@ -1,0 +1,65 @@
+<script>
+	import { Command } from '$lib';
+
+	// prettier-ignore
+	const ten_first_names = ["John", "Doe", "Jane", "Smith", "Michael", "Brown", "William", "Johnson", "David", "Williams"];
+	// prettier-ignore
+	const ten_middle_names = ["James", "Lee", "Robert", "Michael", "David", "Joseph", "Thomas", "Charles", "Christopher", "Daniel"];
+	// prettier-ignore
+	const ten_last_names = ["Smith", "Johnson", "Williams", "Brown", "Jones", "Garcia", "Miller", "Davis", "Rodriguez", "Martinez"];
+
+	const names = ten_first_names
+		.map((first) => {
+			return ten_middle_names.map((middle) => {
+				return ten_last_names.map((last) => {
+					return `${first} ${middle} ${last}`;
+				});
+			});
+		})
+		.flat(2)
+		.slice(350);
+
+	let view = 'sync';
+</script>
+
+<div style:padding="16px">
+	<div style:padding-bottom="16px" style:padding-top="16px">
+		<label for="sync">
+			<input type="radio" name="view" value="sync" bind:group={view} />
+			Sync
+		</label>
+		<label for="async" style="padding-left: 16px;">
+			<input type="radio" name="view" value="async" bind:group={view} />
+			Async
+		</label>
+	</div>
+	{#if view === 'async'}
+		<Command.Root loop>
+			<Command.Input withSleep placeholder="Search items..." />
+			<Command.Empty>No item found.</Command.Empty>
+
+			<Command.List
+				class="h-[var(--cmdk-list-height)]"
+				style="height: 200px; overflow-y: auto; max-width: 300px;"
+			>
+				{#each names as txt (txt)}
+					<Command.Item value={txt}>{txt}</Command.Item>
+				{/each}
+			</Command.List>
+		</Command.Root>
+	{:else}
+		<Command.Root loop>
+			<Command.Input placeholder="Search items..." />
+			<Command.Empty>No item found.</Command.Empty>
+
+			<Command.List
+				class="h-[var(--cmdk-list-height)]"
+				style="height: 200px; overflow-y: auto; max-width: 300px;"
+			>
+				{#each names as txt (txt)}
+					<Command.Item value={txt}>{txt}</Command.Item>
+				{/each}
+			</Command.List>
+		</Command.Root>
+	{/if}
+</div>


### PR DESCRIPTION
Closes: #45 

This PR cleans up a few of the internals that would cause the page to crash if a large list was rendered. There is still a slight delay at the beginning of typing when trying to filter a large list that I haven't been able to solve just yet. Some of these things may be related to the DOM updates that have to occur.

I'd be thrilled if someone else could take a look into how we can make that seamless as well, but this is enough of an improvement to merge for the time being. 