### PR TITLE
feat: expose keydown event from Input component

### DIFF
--- a/.changeset/dull-panthers-divide.md
+++ b/.changeset/dull-panthers-divide.md
@@ -1,0 +1,5 @@
+---
+"cmdk-sv": patch
+---
+
+Expose keydown event from Input component

--- a/src/lib/cmdk/components/CommandInput.svelte
+++ b/src/lib/cmdk/components/CommandInput.svelte
@@ -73,6 +73,7 @@
 		bind:value
 		use:action
 		{...$$restProps}
+		on:keydown
 		on:input
 		on:focus
 		on:blur

--- a/src/lib/cmdk/types.ts
+++ b/src/lib/cmdk/types.ts
@@ -248,6 +248,7 @@ export type DialogProps<
 //
 
 export type InputEvents = {
+	keydown: KeyboardEvent;
 	blur: FocusEvent;
 	input: Event;
 	focus: FocusEvent;


### PR DESCRIPTION
Allows to easily add custom behavior e.g. for `Enter` key inside the Input field.