### PR TITLE
chore: Update `svelte-package`

### DIFF
--- a/.changeset/slimy-insects-worry.md
+++ b/.changeset/slimy-insects-worry.md
@@ -1,0 +1,5 @@
+---
+'cmdk-sv': patch
+---
+
+chore: Updated `svelte-package` to fix malformed package build

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-vercel": "^4.0.0",
 		"@sveltejs/kit": "^2.0.0",
-		"@sveltejs/package": "^2.2.2",
+		"@sveltejs/package": "^2.2.7",
 		"@sveltejs/vite-plugin-svelte": "^3.0.0",
 		"@svitejs/changesets-changelog-github-compact": "^1.1.0",
 		"@types/prismjs": "^1.26.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,8 +26,8 @@ devDependencies:
     specifier: ^2.0.0
     version: 2.5.2(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@4.2.2)(vite@5.1.4)
   '@sveltejs/package':
-    specifier: ^2.2.2
-    version: 2.2.2(svelte@4.2.2)(typescript@5.2.2)
+    specifier: ^2.2.7
+    version: 2.2.7(svelte@4.2.2)(typescript@5.2.2)
   '@sveltejs/vite-plugin-svelte':
     specifier: ^3.0.0
     version: 3.0.2(svelte@4.2.2)(vite@5.1.4)
@@ -1262,19 +1262,19 @@ packages:
       vite: 5.1.4
     dev: true
 
-  /@sveltejs/package@2.2.2(svelte@4.2.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-rP3sVv6cAntcdcG4r4KspLU6nZYYUrHJBAX3Arrw0KJFdgxtlsi2iDwN0Jwr/vIkgjcU0ZPWM8kkT5kpZDlWAw==}
+  /@sveltejs/package@2.2.7(svelte@4.2.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-/vvmrQO2mMvROdM/iGRHtRn+ValnK9xzB50pqRcX0IvoeVoTq7uhYf+KifrZTluBA+km6AX/WXRXajrgrgbmvw==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
     peerDependencies:
-      svelte: ^3.44.0 || ^4.0.0
+      svelte: ^3.44.0 || ^4.0.0 || ^5.0.0-next.1
     dependencies:
-      chokidar: 3.5.3
+      chokidar: 3.6.0
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.5.4
       svelte: 4.2.2
-      svelte2tsx: 0.6.23(svelte@4.2.2)(typescript@5.2.2)
+      svelte2tsx: 0.7.3(svelte@4.2.2)(typescript@5.2.2)
     transitivePeerDependencies:
       - typescript
     dev: true
@@ -1941,6 +1941,21 @@ packages:
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
+  /chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
     dependencies:
       anymatch: 3.1.3
@@ -4933,10 +4948,10 @@ packages:
       - typescript
     dev: true
 
-  /svelte2tsx@0.6.23(svelte@4.2.2)(typescript@5.2.2):
-    resolution: {integrity: sha512-3bwd1PuWUA3oEXy8+85zrLDnmJOsVpShpKVAehGWeYsz/66zMihTpRpUN97VVAKTZbO5tP4wnchHUXYs0zOwdw==}
+  /svelte2tsx@0.7.3(svelte@4.2.2)(typescript@5.2.2):
+    resolution: {integrity: sha512-yrjJFvqp32Ag4Oke+T1xXZLqMNrS0gjzAM//+L6+7OhXWMDuMs0fkyb9ymixK9keVOLJ1GbeEVfg59c3E2IN+w==}
     peerDependencies:
-      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0
+      svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
       typescript: ^4.9.4 || ^5.0.0
     dependencies:
       dedent-js: 1.0.1


### PR DESCRIPTION
closes #63 

`module: "NodeNext"` was set in the `tsconfig.json`, but `@sveltejs/package` wasn't updated to latest, which contains a fix for overwriting the `module` field to `esnext` during package build to prevent the generation of commonjs.