### PR TITLE
Support meta key and home/end shortcuts

### DIFF
--- a/.changeset/tame-candles-complain.md
+++ b/.changeset/tame-candles-complain.md
@@ -1,0 +1,5 @@
+---
+'cmdk-sv': patch
+---
+
+Support meta key and home/end shortcuts

--- a/.changeset/tame-candles-complain.md
+++ b/.changeset/tame-candles-complain.md
@@ -2,4 +2,4 @@
 'cmdk-sv': patch
 ---
 
-Support meta key and home/end shortcuts
+fix: Support meta key and home/end shortcuts

--- a/src/lib/cmdk/command.ts
+++ b/src/lib/cmdk/command.ts
@@ -6,7 +6,6 @@ import {
 	omit,
 	generateId,
 	toWritableStores,
-	isHTMLElement,
 	isUndefined,
 	kbd,
 	removeUndefined,

--- a/src/lib/cmdk/command.ts
+++ b/src/lib/cmdk/command.ts
@@ -412,6 +412,7 @@ export function createCommand(props: CommandProps) {
 		const items = getValidItems(rootEl);
 		const item = items[index];
 		if (!item) return;
+		updateState('value', item.getAttribute(VALUE_ATTR) ?? '');
 	}
 
 	function updateSelectedByChange(change: 1 | -1) {


### PR DESCRIPTION
I assumed that this library would support `Home` and `End` for going to the top and bottom of the command items but it didn't work. After inspecting the code, I noticed it's supposed to but doesn't actually work because the method ([`/src/lib/cmdk/command.ts#409`](https://github.com/huntabyte/cmdk-sv/blob/e097719ab4fd54bfdcc7f942ca432b237473bf8f/src/lib/cmdk/command.ts#L409)) doesn't trigger a state update.

As a result, this also fixes `Meta` + `ArrowUp`/`ArrowDown` to jump to the beginning or end. Since the code is already there I've assumed this was intended to be supported otherwise the `updateSelectedToIndex` doesn't actually do anything.