### PR TITLE
fix: select first value after search

### DIFF
--- a/.changeset/brave-meals-build.md
+++ b/.changeset/brave-meals-build.md
@@ -1,0 +1,5 @@
+---
+'cmdk-sv': patch
+---
+
+fix: select first value after search

--- a/src/lib/cmdk/command.ts
+++ b/src/lib/cmdk/command.ts
@@ -244,6 +244,7 @@ export function createCommand(props: CommandProps) {
 				tick().then(() =>
 					state.update((curr) => {
 						curr.value = selectFirstItem() ?? '';
+						props.onValueChange?.(curr.value);
 						return curr;
 					})
 				);


### PR DESCRIPTION
#17 and 8f8fa9f added code so that first value is selected after search is executed (fixed #16). However, though internal state was updated, it was not propagated to `onValueChange` and exposed `value`.

You can easily notice it in the Framer example from the website:
1. Search for any component in the input.
2. Notice that the selected component on the right side does not change.

This PR fixes this, though since the state management in this library is pretty complex, please double check that it won't break anything.