### PR TITLE
Escape problematic characters in selector

### DIFF
--- a/.changeset/pretty-swans-travel.md
+++ b/.changeset/pretty-swans-travel.md
@@ -1,0 +1,5 @@
+---
+"cmdk-sv": patch
+---
+
+fix: escape problematic characters in selectors

--- a/src/lib/cmdk/components/CommandInput.svelte
+++ b/src/lib/cmdk/components/CommandInput.svelte
@@ -21,7 +21,9 @@
 
 	const selectedItemId = derived([valueStore, commandEl], ([$value, $commandEl]) => {
 		if (!isBrowser) return undefined;
-		const item = $commandEl?.querySelector(`${ITEM_SELECTOR}[${VALUE_ATTR}="${$value}"]`);
+		const item = $commandEl?.querySelector(
+			`${ITEM_SELECTOR}[${VALUE_ATTR}="${CSS.escape($value)}"]`
+		);
 		return item?.getAttribute('id');
 	});
 


### PR DESCRIPTION
Fixes https://github.com/huntabyte/cmdk-sv/issues/102

## Test steps:

### Setup
1. Set up some command line items to use.
   1. Add a command item with double quotes in its name. Ex. 
    ```
    `This is a value with "double" quotes`
    ```
    2. Add a command item with \\" in its name: Ex.
    ```
    `This the the \\"value\\"`
    ```
2. Use the options in a Command instance and view it in a browser with dev tools open so you can see the console logs.
### Steps

1. Hover over the command item with the name with double quotes
2. [ ] There are no errors logged to the console
3. Hover over the command item with escaped double quotes in its name
4. [ ] There are no errors logged to the console
5. [ ] You are able to filter the command items by typing in a string containing double quotes